### PR TITLE
Add field to configure container environment

### DIFF
--- a/templates/cronjob.yaml
+++ b/templates/cronjob.yaml
@@ -48,6 +48,10 @@ spec:
               args:
                 {{- . | toYaml | nindent 16 }}
               {{- end }}
+              {{- with $config.env }}
+              env:
+                {{- . | toYaml | nindent 16 }}
+              {{- end }}
               {{- with $config.volumeMounts }}
               volumeMounts:
                 {{- . | toYaml | nindent 16 }}


### PR DESCRIPTION
There's currently no way to set environment variables in the container. With this change, one can specify environment variables in their values.yaml like the following:

```yaml
containers:
  cleanup:
    env:
    - name: TIMEOUT
      value: 10s
```